### PR TITLE
Footstep: Smart-contracts for jetton voting platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The list of the TON Footsteps represented in the GitHub [issues](https://github.
 | [Gusarich](https://github.com/Gusarich) | Article: Random number generation in smart contracts | [Issue](https://github.com/ton-society/ton-footsteps/issues/114) |
 | [Nikita Kuznetsov](https://github.com/KuznetsovNikita) | Development TON Connect 2.0 in OpenMask | [Issue](https://github.com/ton-society/ton-footsteps/issues/107) |
 | [AlexG](https://github.com/reveloper) | TACT lang documentation | [Issue](https://github.com/ton-society/ton-footsteps/issues/105)|
+| [EgorT](https://github.com/sikvelsigma) | Smart-contracts for jetton voting platform | [Issue](https://github.com/ton-society/ton-footsteps/issues/142) |
 
 
 ### The TON Footsteps committee


### PR DESCRIPTION
PR for #142 

Done in: 
https://github.com/ston-fi/jvp-core

The contracts allow multiple users to cast their vote for addresses, including Jetton addresses.

 TON wallet for reward: 
 EQBoTw0OzTblnzvV_nNVcSsQHlSykMg4pKrBbw-3ZiQrBb7D